### PR TITLE
Add dotenv for Github token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,23 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Dependency directories
 node_modules/
+
+# dotenv environment variables file
+.env
+.env.test
+
+# Stores VSCode versions used for testing VSCode extensions
+.vscode-test
+
+# Other
 debug.js
 erik.js
 eslintrc.json
 smell.java
-README.node_modules

--- a/README.md
+++ b/README.md
@@ -108,14 +108,12 @@ git clone https://github.com/yy2111/REST
 
 Go to your profile page on github, select "Settings" --> "Developer settings" --> "Personal access tokens", and then click on "Generate new token" button.
 
-Save your token in an [environment variable]. This step may be a little tricky, and please read instructions on this page carefully: https://github.com/chrisparnin/EngineeringBasics/blob/master/Shells.md#environment-variables.
-
-```bash
-# Mac/Linux
-export GITHUBTOKEN="xxx"
-# Windows
-setx GITHUBTOKEN xxx
+Create a file `.env` in the root of the project and add your access token.
 ```
+GITHUBTOKEN=abc123
+```
+
+> **Do not** push the `.env` file to github. This will expose your Github token.
 
 ### 2. Test sample code
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ var urlRoot = "https://api.github.com";
 
 var userId = "yy2111";
 var config = {};
+
 // Retrieve our api token from the environment variables.
+require('dotenv').config();
 config.token = process.env.GITHUBTOKEN;
 
 if( !config.token )

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,6 +399,11 @@
         "esutils": "^2.0.2"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Practice with REST concepts.",
   "scripts": {
+    "start": "node index.js",
     "test": "mocha --reporter spec"
   },
   "main": "index.js",
@@ -11,6 +12,7 @@
   ],
   "dependencies": {
     "chalk": "^2.4.2",
+    "dotenv": "^8.2.0",
     "parse-link-header": "^1.0.1",
     "request": "^2.88.0",
     "unirest": "^0.6.0"


### PR DESCRIPTION
Updated to use a local `.env` file for loading Github token into `process.env`.